### PR TITLE
fix(extensions): ignore .d.ts extensions

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 const config = {
   VALID_FILE_EXTENSIONS: [".ts", ".js", ".mjs"],
+  INVALID_NAME_SUFFIXES: [".d.ts"],
   IGNORE_PREFIX_CHAR: "_",
   DEFAULT_METHOD_EXPORTS: [
     "get",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,6 +11,9 @@ import config from "./config"
  */
 export const isFileIgnored = (parsedFile: ParsedPath) =>
   !config.VALID_FILE_EXTENSIONS.includes(parsedFile.ext.toLowerCase()) ||
+  config.INVALID_NAME_SUFFIXES.some(suffix =>
+    parsedFile.base.toLowerCase().endsWith(suffix)
+  ) ||
   parsedFile.name.startsWith(config.IGNORE_PREFIX_CHAR) ||
   parsedFile.dir.startsWith(`/${config.IGNORE_PREFIX_CHAR}`)
 


### PR DESCRIPTION
Ignore type declarations when using a build.

Would also be nice to genericize this and add a callback that lets you define which paths you want included, but this is good enough for now.