### PR TITLE
Breaking Change: Add ESM and CJS support

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 const config = {
   VALID_FILE_EXTENSIONS: [".ts", ".js", ".mjs"],
+  INVALID_NAME_SUFFIXES: [".d.ts"],
   IGNORE_PREFIX_CHAR: "_",
   DEFAULT_METHOD_EXPORTS: [
     "get",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,13 +12,13 @@ export { createRouter }
  * Routing middleware
  *
  * ```ts
- * app.use("/", router())
+ * app.use("/", await router())
  * ```
  *
  * @param options An options object (optional)
  */
-export const router = (options: Options = {}) => {
-  return createRouter(Router(), options)
+export const router = async (options: Options = {}) => {
+  return await createRouter(Router(), options)
 }
 
 export { Options }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -43,7 +43,7 @@ export const walkTree = (directory: string, tree: string[] = []) => {
  *
  * @returns
  */
-export const generateRoutes = (files: File[]) => {
+export const generateRoutes = async (files: File[]) => {
   const routes: Route[] = []
 
   for (const file of files) {
@@ -58,7 +58,7 @@ export const generateRoutes = (files: File[]) => {
 
     const url = convertParamSyntax(directory + name)
     const priority = calculatePriority(url)
-    const exports = require(path.join(file.path, file.name))
+    const exports = await import(path.join(file.path, file.name))
 
     routes.push({
       url,

--- a/src/router.ts
+++ b/src/router.ts
@@ -12,6 +12,7 @@ const cjsMainFilename = typeof require !== "undefined" && require.main?.filename
 const REQUIRE_MAIN_FILE = path.dirname(cjsMainFilename || process.cwd())
 
 type ExpressLike = Express | Router
+
 /**
  * Attach routes to an Express app or router instance
  *
@@ -50,8 +51,7 @@ const createRouter = async <T extends ExpressLike = ExpressLike>(
 
     // wildcard default export route matching
     if (typeof exports.default !== "undefined") {
-      const defaultHandlers = getHandlers(exports.default)
-      app.all.apply(null, [url, ...defaultHandlers])
+      app.all.apply(null, [url, ...getHandlers(exports.default)])
     }
   }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,4 +1,4 @@
-import type { Express } from "express"
+import type { Express, Router } from "express"
 import path from "path"
 
 import type { Options } from "./types"
@@ -8,8 +8,10 @@ import config from "./config"
 import { generateRoutes, walkTree } from "./lib"
 import { getHandlers, getMethodKey } from "./utils"
 
-const REQUIRE_MAIN_FILE = path.dirname(require.main?.filename || process.cwd())
+const cjsMainFilename = typeof require !== "undefined" && require.main?.filename
+const REQUIRE_MAIN_FILE = path.dirname(cjsMainFilename || process.cwd())
 
+type ExpressLike = Express | Router
 /**
  * Attach routes to an Express app or router instance
  *
@@ -20,12 +22,15 @@ const REQUIRE_MAIN_FILE = path.dirname(require.main?.filename || process.cwd())
  * @param app An express app or router instance
  * @param options An options object (optional)
  */
-const createRouter = <T = Express>(app: T, options: Options = {}): T => {
+const createRouter = async <T extends ExpressLike = ExpressLike>(
+  app: T,
+  options: Options = {}
+): Promise<T> => {
   const files = walkTree(
     options.directory || path.join(REQUIRE_MAIN_FILE, "routes")
   )
 
-  const routes = generateRoutes(files)
+  const routes = await generateRoutes(files)
 
   for (const { url, exports } of routes) {
     const exportedMethods = Object.entries(exports)
@@ -45,7 +50,8 @@ const createRouter = <T = Express>(app: T, options: Options = {}): T => {
 
     // wildcard default export route matching
     if (typeof exports.default !== "undefined") {
-      ;(app as unknown as Express).all(url, ...getHandlers(exports.default))
+      const defaultHandlers = getHandlers(exports.default)
+      app.all.apply(null, [url, ...defaultHandlers])
     }
   }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -17,7 +17,7 @@ type ExpressLike = Express | Router
  * Attach routes to an Express app or router instance
  *
  * ```ts
- * createRouter(app)
+ * await createRouter(app)
  * ```
  *
  * @param app An express app or router instance

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export interface Options {
    * The routes entry directory (optional)
    *
    * ```ts
-   * createRouter(app, {
+   * await createRouter(app, {
    *  directory: path.join(__dirname, "pages")
    * })
    * ```
@@ -20,7 +20,7 @@ export interface Options {
    *
    * const { app } = ws(express())
    *
-   * createRouter(app, {
+   * await createRouter(app, {
    *  // without this the exported ws handler is ignored
    *  additionalMethods: ["ws"]
    * })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@ import type { ParsedPath } from "path"
 import type { Route } from "./types"
 
 import config from "./config"
+import { Handler } from "express"
 
 /**
  * @param parsedFile
@@ -71,9 +72,8 @@ export const calculatePriority = (url: string) => {
   return depth + specifity
 }
 
-export const getHandlers = handler => {
+export const getHandlers = (handler: Handler | Handler[]): Handler[] => {
   if (!Array.isArray(handler)) return [handler]
-
   return handler
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,9 @@
+import type { Handler } from "express"
 import type { ParsedPath } from "path"
 
 import type { Route } from "./types"
 
 import config from "./config"
-import { Handler } from "express"
 
 /**
  * @param parsedFile

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,6 +11,9 @@ import config from "./config"
  */
 export const isFileIgnored = (parsedFile: ParsedPath) =>
   !config.VALID_FILE_EXTENSIONS.includes(parsedFile.ext.toLowerCase()) ||
+  config.INVALID_NAME_SUFFIXES.some(suffix =>
+    parsedFile.base.toLowerCase().endsWith(suffix)
+  ) ||
   parsedFile.name.startsWith(config.IGNORE_PREFIX_CHAR) ||
   parsedFile.dir.startsWith(`/${config.IGNORE_PREFIX_CHAR}`)
 


### PR DESCRIPTION
Changing the code from `require` to `await import` has it work both in ESM and CJS codebases.

This is a breaking change due to the async nature of the router. All code would need to be migrated from `router(...)` to `await router()`