### PR TITLE
v3 (breaking API change)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,11 @@
 {
   "rules": {
     "no-console": "error"
-  }
+  },
+  "ignorePatterns": [
+    "node_modules/",
+    "dist/",
+    "examples/",
+    "rollup.config.js"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ app.use(async (err, req, res, next) => {
 
 ### Catch-All (unstable)
 
-This library lets you extend dynamic paths to catch-all routes by prefixing it with three dots `...` inside the brackets. This will make that route match itself but also all subsequent routes within that route.
+This library lets you extend dynamic routes to catch-all routes by prefixing it with three dots `...` inside the brackets. This will make that route match itself but also all subsequent routes within that route.
 
 **Note:** Since this feature got added recently, it might be unstable. Feedback is welcome.
 
@@ -188,11 +188,11 @@ export const get = async (req, res) => {
 }
 ```
 
-- `/routes/users/[...catchall].js` matches /users/a, /users/a/b and so on, but **not** /users.
+- `routes/users/[...catchall].js` matches /users/a, /users/a/b and so on, but **not** /users.
 
 ## Migrating from v2
 
-The latest version v3 fixed stable support for ESM & CJS compatibility. But also **introduced a breaking change** in the library's API. To upgrade, first upgrade to the latest version from npm.
+The latest version v3 fixed stable support for ESM & CJS compatibility. But also **introduced a breaking change** in the library's API. To upgrade, first install the latest version from npm.
 
 ### Upgrade version
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install express-file-routing
 
 ## How to use
 
-Fundamentally, there are two ways of adding this library to your codebase: either as a middleware `app.use("/", router())`, which will add a separate [mini-router](http://expressjs.com/en/5x/api.html#router) to your app, or by wrapping your whole Express instance with a `createRouter(app)`, which will bind the routes directly to your app. In most cases, it doesn't matter on what option you decide, even though one or the other might perform better in some scenarios.
+Fundamentally, there are two ways of adding this library to your codebase: either as a middleware `app.use("/", await router())`, which will add a separate [mini-router](http://expressjs.com/en/5x/api.html#router) to your app, or by wrapping your whole Express instance with a `await createRouter(app)`, which will bind the routes directly to your app. In most cases, it doesn't matter on what option you decide, even though one or the other might perform better in some scenarios.
 
 - app.ts (main)
 
@@ -25,10 +25,10 @@ import createRouter, { router } from "express-file-routing"
 const app = express()
 
 // Option 1
-app.use("/", router()) // as router middleware or
+app.use("/", await router()) // as router middleware or
 
 // Option 2
-createRouter(app) // as wrapper function
+await createRouter(app) // as wrapper function
 
 app.listen(2000)
 ```
@@ -70,12 +70,12 @@ Files inside your project's `/routes` directory will get matched an url path aut
 ## API
 
 ```ts
-createRouter(app, {
+await createRouter(app, {
   directory: path.join(__dirname, "routes"),
   additionalMethods: ["ws", ...]
 })
 // or
-app.use("/", router({
+app.use("/", await router({
   directory: path.join(__dirname, "routes"),
   additionalMethods: ["ws", ...]
 }))
@@ -139,7 +139,7 @@ import ws from "express-ws"
 
 const { app } = ws(express())
 
-createRouter(app, {
+await createRouter(app, {
   additionalMethods: ["ws"]
 })
 
@@ -167,7 +167,7 @@ It is essential to catch potential errors (500s, 404s etc.) within your route ha
 Defining custom error-handling middleware functions should happen _after_ applying your file-system routes.
 
 ```ts
-app.use("/", router()) // or createRouter(app)
+app.use("/", await router()) // or await createRouter(app)
 
 app.use(async (err, req, res, next) => {
   ...

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Files inside your project's `/routes` directory will get matched an url path aut
     ├── index.ts // index routes
     ├── posts
         ├── index.ts
-        └── :id.ts or [id].ts // dynamic params
+        └── [id].ts or :id.ts // dynamic params
     └── users.ts
 └── package.json
 ```
@@ -90,14 +90,14 @@ app.use("/", await router({
 
 ### HTTP Method Matching
 
-If you export functions named e.g. `get`, `post`, `put`, `patch`, `delete`/`del` [etc.](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) those will get matched their corresponding http method automatically.
+If you export functions named e.g. `get`, `post`, `put`, `patch`, `delete`/`del` [etc.](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) from a route file, those will get matched their corresponding http method automatically.
 
 ```ts
 export const get = async (req, res) => { ... }
 
 export const post = async (req, res) => { ... }
 
-// it's not allowed to name variables 'delete': try 'del' instead
+// since it's not allowed to name constants 'delete', try 'del' instead
 export const del = async (req, res) => { ... }
 
 // you can still use a wildcard default export in addition
@@ -111,6 +111,7 @@ export default async (req, res) => { ... }
 You can add isolated, route specific middlewares by exporting an array of Express request handlers from your route file.
 
 ```ts
+// routes/dashboard
 import { rateLimit, bearerToken, userAuth } from "../middlewares"
 
 export const get = [
@@ -193,9 +194,13 @@ export const get = async (req, res) => {
 
 The latest version v3 fixed stable support for ESM & CJS compatibility. But also **introduced a breaking change** in the library's API. To upgrade, first upgrade to the latest version from npm.
 
+### Upgrade version
+
 ```
 npm install express-file-routing@latest
 ```
+
+### Await the router
 
 Registering the file-router in v2 was synchronous. Newer versions require you to await the router. So the only change in your codebase will be to await the router instead of calling it synchronously:
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ app.listen(2000)
 - routes/index.ts
 
 ```ts
-export default async (req, res) => {
+export const get = async (req, res) => {
   if (req.method !== "GET") return res.status(405)
 
   return res.json({ hello: "world" })
@@ -188,3 +188,35 @@ export const get = async (req, res) => {
 ```
 
 - `/routes/users/[...catchall].js` matches /users/a, /users/a/b and so on, but **not** /users.
+
+## Migrating from v2
+
+The latest version v3 fixed stable support for ESM & CJS compatibility. But also **introduced a breaking change** in the library's API. To upgrade, first upgrade to the latest version from npm.
+
+```
+npm install express-file-routing@latest
+```
+
+Registering the file-router in v2 was synchronous. Newer versions require you to await the router. So the only change in your codebase will be to await the router instead of calling it synchronously:
+
+```diff
+const app = express()
+
+- app.use(router())
++ app.use(await router())
+
+app.listen(2000)
+```
+
+Or if you were using `createRouter()`:
+
+```diff
+const app = express()
+
+- createRouter(app)
++ await createRouter(app)
+
+app.listen(2000)
+```
+
+**Note:** If you environment does not support top-level await, you might need to wrap you code in an async function.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,6 @@
-/** @type {import('ts-jest').JestConfigWithTsJest} */
+/**
+ * @type {import("ts-jest").JestConfigWithTsJest}
+ */
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-file-routing",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.5",
   "description": "Simple file-system based routing for Express",
   "author": "Matthias Halfmann",
   "repository": "matthiaaas/express-file-routing",

--- a/package.json
+++ b/package.json
@@ -1,17 +1,23 @@
 {
   "name": "express-file-routing",
-  "version": "3.0.0-beta.0",
-  "description": "Simple system-based file routing for Express",
+  "version": "3.0.0-beta.3",
+  "description": "Simple file-system based routing for Express",
   "author": "Matthias Halfmann",
   "repository": "matthiaaas/express-file-routing",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "type": "module",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
   "scripts": {
     "test": "jest",
-    "build": "rollup -c",
+    "build": "npm run build:rollup",
+    "build:rollup": "rollup -c",
+    "build:tsc": "tsc && tsc --module commonjs --outDir dist/cjs",
     "prepublish": "npm run build",
     "dev": "ts-node-dev --transpile-only --files --quiet ./examples/with-typescript/app.ts"
+  },
+  "exports": {
+    "import": "./dist/esm/index.js",
+    "require": "./dist/cjs/index.js"
   },
   "keywords": [
     "express",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-file-routing",
-  "version": "2.1.4",
+  "version": "3.0.0-beta.0",
   "description": "Simple system-based file routing for Express",
   "author": "Matthias Halfmann",
   "repository": "matthiaaas/express-file-routing",
@@ -9,6 +9,7 @@
   "scripts": {
     "test": "jest",
     "build": "rollup -c",
+    "prepublish": "npm run build",
     "dev": "ts-node-dev --transpile-only --files --quiet ./examples/with-typescript/app.ts"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "repository": "matthiaaas/express-file-routing",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "type": "module",
   "scripts": {
     "test": "jest",
     "build": "rollup -c",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-file-routing",
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "description": "Simple file-system based routing for Express",
   "author": "Matthias Halfmann",
   "repository": "matthiaaas/express-file-routing",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,7 +9,7 @@ export default {
   input: "src/index.ts",
   output: [
     {
-      file: "dist/esm/index.js",
+      file: pkg.module,
       format: "esm",
       exports: "named",
       sourcemap: true,
@@ -17,7 +17,7 @@ export default {
       esModule: true
     },
     {
-      file: "dist/cjs/index.js",
+      file: pkg.main,
       format: "cjs",
       exports: "named",
       sourcemap: true,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ export default {
   output: [
     {
       file: pkg.main,
-      format: "cjs",
+      format: "es",
       exports: "named",
       sourcemap: true,
       strict: false

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,17 +2,28 @@ import typescript from "rollup-plugin-typescript2"
 
 import pkg from "./package.json"
 
+/**
+ * @type {import("rollup").RollupOptions}
+ */
 export default {
   input: "src/index.ts",
   output: [
     {
-      file: pkg.main,
-      format: "es",
+      file: "dist/esm/index.js",
+      format: "esm",
+      exports: "named",
+      sourcemap: true,
+      strict: false,
+      esModule: true
+    },
+    {
+      file: "dist/cjs/index.js",
+      format: "cjs",
       exports: "named",
       sourcemap: true,
       strict: false
     }
   ],
-  plugins: [typescript({ objectHashIgnoreUnknownHack: true })],
+  plugins: [typescript()],
   external: ["express", "path", "fs"]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,13 +12,13 @@ export { createRouter }
  * Routing middleware
  *
  * ```ts
- * app.use("/", router())
+ * app.use("/", await router())
  * ```
  *
  * @param options An options object (optional)
  */
-export const router = (options: Options = {}) => {
-  return createRouter(Router(), options)
+export const router = async (options: Options = {}) => {
+  return await createRouter(Router(), options)
 }
 
 export { Options }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -4,6 +4,7 @@ import path from "path"
 import type { File, Route } from "./types"
 
 import {
+  buildRoutePath,
   buildRouteUrl,
   calculatePriority,
   isFileIgnored,
@@ -12,8 +13,10 @@ import {
 } from "./utils"
 
 /**
+ * Recursively walk a directory and return all nested files.
+ *
  * @param directory The directory path to walk recursively
- * @param tree
+ * @param tree The tree of directories leading to the current directory
  *
  * @returns An array of all nested files in the specified directory
  */
@@ -39,9 +42,11 @@ export const walkTree = (directory: string, tree: string[] = []) => {
 }
 
 /**
- * @param files
+ * Generate routes from an array of files by loading them as modules.
  *
- * @returns
+ * @param files An array of files to generate routes from
+ *
+ * @returns An array of routes
  */
 export const generateRoutes = async (files: File[]) => {
   const routes: Route[] = []
@@ -51,12 +56,8 @@ export const generateRoutes = async (files: File[]) => {
 
     if (isFileIgnored(parsedFile)) continue
 
-    const directory = parsedFile.dir === parsedFile.root ? "" : parsedFile.dir
-    const name = parsedFile.name.startsWith("index")
-      ? parsedFile.name.replace("index", "")
-      : `/${parsedFile.name}`
-
-    const url = buildRouteUrl(directory + name)
+    const routePath = buildRoutePath(parsedFile)
+    const url = buildRouteUrl(routePath)
     const priority = calculatePriority(url)
     const exports = await import(path.join(file.path, file.name))
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -58,7 +58,7 @@ export const generateRoutes = async (files: File[]) => {
 
     const url = buildRouteUrl(directory + name)
     const priority = calculatePriority(url)
-    const exports = await import("file://" + path.join(file.path, file.name))
+    const exports = await import(path.join(file.path, file.name))
 
     routes.push({
       url,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -58,7 +58,7 @@ export const generateRoutes = async (files: File[]) => {
 
     const url = buildRouteUrl(directory + name)
     const priority = calculatePriority(url)
-    const exports = await import(path.join(file.path, file.name))
+    const exports = await import("file://" + path.join(file.path, file.name))
 
     routes.push({
       url,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -43,7 +43,7 @@ export const walkTree = (directory: string, tree: string[] = []) => {
  *
  * @returns
  */
-export const generateRoutes = (files: File[]) => {
+export const generateRoutes = async (files: File[]) => {
   const routes: Route[] = []
 
   for (const file of files) {
@@ -58,7 +58,7 @@ export const generateRoutes = (files: File[]) => {
 
     const url = buildRouteUrl(directory + name)
     const priority = calculatePriority(url)
-    const exports = require(path.join(file.path, file.name))
+    const exports = await import(path.join(file.path, file.name))
 
     routes.push({
       url,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -7,10 +7,15 @@ import {
   buildRoutePath,
   buildRouteUrl,
   calculatePriority,
+  isCjs,
   isFileIgnored,
   mergePaths,
   prioritizeRoutes
 } from "./utils"
+
+const IS_ESM = !isCjs()
+
+const MODULE_IMPORT_PREFIX = IS_ESM ? "file://" : ""
 
 /**
  * Recursively walk a directory and return all nested files.
@@ -59,7 +64,9 @@ export const generateRoutes = async (files: File[]) => {
     const routePath = buildRoutePath(parsedFile)
     const url = buildRouteUrl(routePath)
     const priority = calculatePriority(url)
-    const exports = await import(path.join(file.path, file.name))
+    const exports = await import(
+      MODULE_IMPORT_PREFIX + path.join(file.path, file.name)
+    )
 
     routes.push({
       url,

--- a/src/router.ts
+++ b/src/router.ts
@@ -5,7 +5,7 @@ import type { ExpressLike, Options } from "./types"
 import config from "./config"
 
 import { generateRoutes, walkTree } from "./lib"
-import { getHandlers, getMethodKey } from "./utils"
+import { getHandlers, getMethodKey, isCjs } from "./utils"
 
 const CJS_MAIN_FILENAME =
   typeof require !== "undefined" && require.main?.filename
@@ -14,7 +14,7 @@ const PROJECT_DIRECTORY = CJS_MAIN_FILENAME
   ? path.dirname(CJS_MAIN_FILENAME)
   : process.cwd()
 
-const IS_CJS = typeof module !== "undefined" && module?.exports
+const IS_CJS = isCjs()
 
 /**
  * Attach routes to an Express app or router instance

--- a/src/router.ts
+++ b/src/router.ts
@@ -8,10 +8,9 @@ import config from "./config"
 import { generateRoutes, walkTree } from "./lib"
 import { getHandlers, getMethodKey } from "./utils"
 
-const cjsMainFilename = typeof require !== "undefined" && require.main?.filename
-const REQUIRE_MAIN_FILE = path.dirname(cjsMainFilename || process.cwd())
-
-type ExpressLike = Express | Router
+const CJS_MAIN_FILENAME =
+  typeof require !== "undefined" && require.main?.filename
+const REQUIRE_MAIN_FILE = path.dirname(CJS_MAIN_FILENAME || process.cwd())
 
 type ExpressLike = Express | Router
 
@@ -52,9 +51,8 @@ const createRouter = async <T extends ExpressLike = ExpressLike>(
     }
 
     // wildcard default export route matching
-    if (typeof exports.default !== "undefined") {
-      app.all.apply(null, [url, ...getHandlers(exports.default)])
-      app.all.apply(app, [url, ...getHandlers(exports.default)])
+    if (typeof exports.default.default !== "undefined") {
+      app.all.apply(app, [url, ...getHandlers(exports.default.default)])
     }
   }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,7 +1,6 @@
-import type { Express, Router } from "express"
 import path from "path"
 
-import type { Options } from "./types"
+import type { ExpressLike, Options } from "./types"
 
 import config from "./config"
 
@@ -10,13 +9,12 @@ import { getHandlers, getMethodKey } from "./utils"
 
 const CJS_MAIN_FILENAME =
   typeof require !== "undefined" && require.main?.filename
+
 const PROJECT_DIRECTORY = CJS_MAIN_FILENAME
   ? path.dirname(CJS_MAIN_FILENAME)
   : process.cwd()
 
 const IS_CJS = typeof module !== "undefined" && module?.exports
-
-type ExpressLike = Express | Router
 
 /**
  * Attach routes to an Express app or router instance

--- a/src/router.ts
+++ b/src/router.ts
@@ -51,8 +51,8 @@ const createRouter = async <T extends ExpressLike = ExpressLike>(
     }
 
     // wildcard default export route matching
-    if (typeof exports.default.default !== "undefined") {
-      app.all.apply(app, [url, ...getHandlers(exports.default.default)])
+    if (typeof exports.default !== "undefined") {
+      app.all.apply(app, [url, ...getHandlers(exports.default)])
     }
   }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -14,6 +14,8 @@ const PROJECT_DIRECTORY = CJS_MAIN_FILENAME
   ? path.dirname(CJS_MAIN_FILENAME)
   : process.cwd()
 
+const IS_CJS = typeof module !== "undefined" && module?.exports
+
 type ExpressLike = Express | Router
 
 /**
@@ -53,6 +55,9 @@ const createRouter = async <T extends ExpressLike = ExpressLike>(
     }
 
     // wildcard default export route matching
+    if (IS_CJS && typeof exports.default.default !== "undefined") {
+      app.all.apply(app, [url, ...getHandlers(exports.default.default)])
+    } else if (!IS_CJS && typeof exports.default !== "undefined") {
       app.all.apply(app, [url, ...getHandlers(exports.default)])
     }
   }

--- a/src/router.ts
+++ b/src/router.ts
@@ -10,7 +10,9 @@ import { getHandlers, getMethodKey } from "./utils"
 
 const CJS_MAIN_FILENAME =
   typeof require !== "undefined" && require.main?.filename
-const REQUIRE_MAIN_FILE = path.dirname(CJS_MAIN_FILENAME || process.cwd())
+const PROJECT_DIRECTORY = CJS_MAIN_FILENAME
+  ? path.dirname(CJS_MAIN_FILENAME)
+  : process.cwd()
 
 type ExpressLike = Express | Router
 
@@ -29,7 +31,7 @@ const createRouter = async <T extends ExpressLike = ExpressLike>(
   options: Options = {}
 ): Promise<T> => {
   const files = walkTree(
-    options.directory || path.join(REQUIRE_MAIN_FILE, "routes")
+    options.directory || path.join(PROJECT_DIRECTORY, "routes")
   )
 
   const routes = await generateRoutes(files)
@@ -51,7 +53,6 @@ const createRouter = async <T extends ExpressLike = ExpressLike>(
     }
 
     // wildcard default export route matching
-    if (typeof exports.default !== "undefined") {
       app.all.apply(app, [url, ...getHandlers(exports.default)])
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,7 +54,9 @@ interface MethodExports {
   [x: string]: Handler
 }
 
-type Exports = MethodExports
+type Exports = MethodExports & {
+  default?: any
+}
 
 export interface Route {
   url: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,9 +54,7 @@ interface MethodExports {
   [x: string]: Handler
 }
 
-type Exports = MethodExports & {
-  default?: MethodExports
-}
+type Exports = MethodExports
 
 export interface Route {
   url: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,6 @@
-import type { Handler } from "express"
+import type { Express, Router, Handler } from "express"
+
+export type ExpressLike = Express | Router
 
 export interface Options {
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export interface Options {
    * The routes entry directory (optional)
    *
    * ```ts
-   * createRouter(app, {
+   * await createRouter(app, {
    *  directory: path.join(__dirname, "pages")
    * })
    * ```
@@ -20,7 +20,7 @@ export interface Options {
    *
    * const { app } = ws(express())
    *
-   * createRouter(app, {
+   * await createRouter(app, {
    *  // without this the exported ws handler is ignored
    *  additionalMethods: ["ws"]
    * })

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,16 +40,26 @@ export interface File {
   rel: string
 }
 
+interface MethodExports {
+  get?: Handler
+  post?: Handler
+  put?: Handler
+  patch?: Handler
+  delete?: Handler
+  head?: Handler
+  connect?: Handler
+  options?: Handler
+  trace?: Handler
+
+  [x: string]: Handler
+}
+
+type Exports = MethodExports & {
+  default?: MethodExports
+}
+
 export interface Route {
   url: string
   priority: number
-  exports: {
-    default?: Handler
-    get?: Handler
-    post?: Handler
-    put?: Handler
-    patch?: Handler
-    delete?: Handler
-    [x: string]: Handler
-  }
+  exports: Exports
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -74,6 +74,15 @@ export const convertParamSyntax = (path: string) => {
 export const convertCatchallSyntax = (url: string) =>
   url.replace(/:\.\.\.\w+/g, "*")
 
+export const buildRoutePath = (parsedFile: ParsedPath) => {
+  const directory = parsedFile.dir === parsedFile.root ? "" : parsedFile.dir
+  const name = parsedFile.name.startsWith("index")
+    ? parsedFile.name.replace("index", "")
+    : `/${parsedFile.name}`
+
+  return directory + name
+}
+
 /**
  * @param path
  *

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import type { Handler } from "express"
 import type { ParsedPath } from "path"
 
 import type { Route } from "./types"
@@ -98,9 +99,8 @@ export const calculatePriority = (url: string) => {
   return depth + specifity + catchall
 }
 
-export const getHandlers = handler => {
+export const getHandlers = (handler: Handler | Handler[]): Handler[] => {
   if (!Array.isArray(handler)) return [handler]
-
   return handler
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,8 @@ import type { Route } from "./types"
 
 import config from "./config"
 
+export const isCjs = () => typeof module !== "undefined" && module?.exports
+
 /**
  * @param parsedFile
  *

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "es6",
     "moduleResolution": "node",
     "sourceMap": true,
-    "outDir": "dist",
+    "outDir": "dist/esm",
     "resolveJsonModule": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
This PR adds native ESM support by still covering CJS.

- Breaks old API since new routes require to be `awaited` in order to properly import instead of requiring routes

```diff
const app = express()

- app.use(router())
+ app.use(await router())

app.listen(2000)
```