### PR TITLE
Bug fix: Handling index files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "express-file-routing",
-  "version": "2.1.2",
+  "version": "3.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "express-file-routing",
-      "version": "2.1.2",
+      "version": "3.0.4",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^4.17.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-file-routing",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Simple file-based routing for Express",
   "author": "Matthias Halfmann",
   "repository": "matthiaaas/express-file-routing",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,13 +79,22 @@ export const convertParamSyntax = (path: string) => {
 export const convertCatchallSyntax = (url: string) =>
   url.replace(/:\.\.\.\w+/g, "*")
 
-export const buildRoutePath = (parsedFile: ParsedPath) => {
-  const directory = parsedFile.dir === parsedFile.root ? "" : parsedFile.dir
-  const name = parsedFile.name.startsWith("index")
-    ? parsedFile.name.replace("index", "")
-    : `/${parsedFile.name}`
-
-  return directory + name
+export const buildRoutePath = (parsedFile: ParsedPath): string => {
+  // Normalize the directory path
+  const normalizedDir = parsedFile.dir === parsedFile.root ? '/' : parsedFile.dir.startsWith('/') ? parsedFile.dir : `/${parsedFile.dir}`;
+  
+  // Handle index files specially
+  if (parsedFile.name === 'index') {
+    return normalizedDir === '/' ? '/' : normalizedDir;
+  }
+  
+  // Handle index.something files (like index.mod)
+  if (parsedFile.name.startsWith('index.')) {
+    return normalizedDir === '/' ? '/' : normalizedDir;
+  }
+  
+  // For regular files
+  return `${normalizedDir === '/' ? '' : normalizedDir}/${parsedFile.name}`;
 }
 
 /**


### PR DESCRIPTION
Fixed up the `buildRoutePath` function to work better with different file structures.

Previously it treated files such as `indexed.js` as `index.js` since file name was matched using `.startsWith()`. 

Changes:
- Overall added proper handling for root directories
- Fixed the index file logic (handles both regular index files and index.something files)
- Made sure paths have the right slashes in the right places