### PR TITLE
feat: allow specifying base URL for routes

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -34,7 +34,14 @@ const createRouter = async <T extends ExpressLike = ExpressLike>(
 
   const routes = await generateRoutes(files)
 
+  // clean up basePath so it only has a leading slash and no trailing slash (if provided)
+  const basePath = options.basePath
+    ? `/${options.basePath.replace(/^\/|\/$/g, "")}`
+    : ""
+
   for (const { url, exports } of routes) {
+    const routeUrl = `${basePath}${url}`
+
     const exportedMethods = Object.entries(exports)
 
     for (const [method, handler] of exportedMethods) {
@@ -47,18 +54,18 @@ const createRouter = async <T extends ExpressLike = ExpressLike>(
       )
         continue
 
-      app[methodKey](url, ...handlers)
+      app[methodKey](routeUrl, ...handlers)
     }
 
     // wildcard default export route matching
     if (typeof exports.default !== "undefined") {
       if (isHandler(exports.default)) {
-        app.all.apply(app, [url, ...getHandlers(exports.default)])
+        app.all.apply(app, [routeUrl, ...getHandlers(exports.default)])
       } else if (
         typeof exports.default === "object" &&
         isHandler(exports.default.default)
       ) {
-        app.all.apply(app, [url, ...getHandlers(exports.default.default)])
+        app.all.apply(app, [routeUrl, ...getHandlers(exports.default.default)])
       }
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,16 @@ export interface Options {
    * ```
    */
   additionalMethods?: string[]
+  /**
+   * Base path of generated routes (optional)
+   *
+   * ```ts
+   * await createRouter(app, {
+   *  basePath: "/api"
+   * })
+   * ```
+   */
+  basePath?: string
 }
 
 export interface File {


### PR DESCRIPTION
This adds the `basePath` parameter to createRouter to allow specifying a base path for all routes provided by the library. For example (my use case) I'm using this library to provide API routes, and want them to be accessible via `/api` without having to add that to my folder structure. Hope it looks good :)

Example use:
```ts
await createRouter(app, {
  basePath: "/api"
})
```